### PR TITLE
Use references when reading and writing to SPI bus

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -14,8 +14,8 @@ defmodule ElixirCircuits.SPI do
 
   @doc """
   Open SPI channel
-  On success, returns an integer file descriptor.
-  Use file descriptor (fd) in subsequent calls to transfer spi bus data
+  On success, returns a reference.
+  Use reference in subsequent calls to transfer spi bus data
 
   Parameters:
   * `device` is the Linux device name for the bus (e.g., "spidev0.0")
@@ -27,7 +27,7 @@ defmodule ElixirCircuits.SPI do
   * `speed_hz`: bus speed (1000000)
   * `delay_us`: delay between transaction (10)
   """
-  @spec open(binary, [spi_option]) :: {:ok, integer}
+  @spec open(binary, [spi_option]) :: {:ok, reference}
   def open(device, spi_opts \\ []) do
     mode = Keyword.get(spi_opts, :mode, 0)
     bits_per_word = Keyword.get(spi_opts, :bits_per_word, 8)
@@ -41,17 +41,17 @@ defmodule ElixirCircuits.SPI do
   send. Since SPI transfers simultaneously send and receive, the return value
   will be a binary of the same length or an error.
   """
-  @spec transfer(integer, binary) :: {:ok, binary} | {:error, term}
-  def transfer(fd, data) do
-    Nif.transfer(fd, data)
+  @spec transfer(reference, binary) :: {:ok, binary} | {:error, term}
+  def transfer(ref, data) do
+    Nif.transfer(ref, data)
   end
 
   @doc """
   Release any resources associated with the given file descriptor
   """
-  @spec close(integer) :: :ok
-  def close(fd) do
-    Nif.close(fd)
+  @spec close(reference) :: :ok
+  def close(ref) do
+    Nif.close(ref)
   end
 
   @doc """

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -2,16 +2,23 @@ defmodule ElixirCircuits.SPI.Nif do
   @on_load {:load_nif, 0}
   @compile {:autoload, false}
 
+  require Logger
+
   @doc """
   Elixir interface to SPI Natively Implemented Funtions (NIFs)
   """
 
   def load_nif() do
     nif_binary = Application.app_dir(:spi, "priv/spi_nif")
-    if File.exists?(nif_binary) do
-      :erlang.load_nif(to_charlist(nif_binary), 0)
-    else
-      IO.puts("WARNING: Not loading SPI NIF since not compiled or not supported on this platform")
+
+    case :erlang.load_nif(to_charlist(nif_binary), 0) do
+      {:error, reason} ->
+        Logger.error(
+          "ElixirCircuits.I2CError: load_nif(#{nif_binary}) failed with #{inspect(reason)}"
+        )
+
+      _ ->
+        :ok
     end
   end
 
@@ -19,11 +26,11 @@ defmodule ElixirCircuits.SPI.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def transfer(_fd, _data) do
+  def transfer(_ref, _data) do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def close(_fd) do
+  def close(_ref) do
     :erlang.nif_error(:nif_not_loaded)
   end
 end

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -1,0 +1,59 @@
+#ifndef SPI_NIF_H
+#define SPI_NIF_H
+
+
+#include "erl_nif.h"
+
+#include <err.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <linux/spi/spidev.h>
+
+#ifndef _IOC_SIZE_BITS
+// Include <asm/ioctl.h> manually on platforms that don't include it
+// from <sys/ioctl.h>.
+#include <asm/ioctl.h>
+#endif
+
+//#define DEBUG
+
+#ifdef DEBUG
+#define log_location stderr
+//#define LOG_PATH "/tmp/elixir_circuits_spi.log"
+#define debug(...) do { enif_fprintf(log_location, __VA_ARGS__); enif_fprintf(log_location, "\r\n"); fflush(log_location); } while(0)
+#define error(...) do { debug(__VA_ARGS__); } while (0)
+#define start_timing() ErlNifTime __start = enif_monotonic_time(ERL_NIF_USEC)
+#define elapsed_microseconds() (enif_monotonic_time(ERL_NIF_USEC) - __start)
+#else
+#define debug(...)
+#define error(...) do { enif_fprintf(stderr, __VA_ARGS__); enif_fprintf(stderr, "\n"); } while(0)
+#define start_timing()
+#define elapsed_microseconds() 0
+#endif
+
+// Max SPI transfer size that we support
+#define SPI_TRANSFER_MAX 4096
+
+
+// SPI NIF Resource.
+struct SpiNifRes {
+    int fd;
+    struct spi_ioc_transfer transfer;
+};
+
+
+// SPI NIF Private data
+struct SpiNifPriv {
+    ErlNifResourceType *spi_nif_res_type;
+    ERL_NIF_TERM atom_ok;
+    ERL_NIF_TERM atom_error;
+};
+
+#endif // SPI_NIF_H


### PR DESCRIPTION
Per review of last SPI pull request:
Abandon code to maintain resource list in the NIF
Switch to using references instead of file descriptors, to identify open channels for reading and writing
Return ":ok" tuple with data, on successful read.
Follow C code standards, 
Format code