### PR TITLE
Remove log message when NIF fails to load

### DIFF
--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -2,24 +2,13 @@ defmodule ElixirCircuits.SPI.Nif do
   @on_load {:load_nif, 0}
   @compile {:autoload, false}
 
-  require Logger
-
   @doc """
   Elixir interface to SPI Natively Implemented Funtions (NIFs)
   """
 
   def load_nif() do
     nif_binary = Application.app_dir(:spi, "priv/spi_nif")
-
-    case :erlang.load_nif(to_charlist(nif_binary), 0) do
-      {:error, reason} ->
-        Logger.error(
-          "ElixirCircuits.I2CError: load_nif(#{nif_binary}) failed with #{inspect(reason)}"
-        )
-
-      _ ->
-        :ok
-    end
+    :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
   def open(_device, _mode, _bits_per_word, _speed_hz, _delay_us) do


### PR DESCRIPTION
It turns out that Erlang already has a reasonable error message. Here's
what I get:

```
08:20:29.252 [warn]  The on_load function for module Elixir.ElixirCircuits.SPI.Nif returned:
{:error, {:load_failed, 'Failed to load NIF library: \'dlopen(/Users/fhunleth/nerves/circuits/spi/_build/dev/lib/spi/priv/spi_nif.so, 2): image not found\''}}
```