### PR TITLE
Rename to circuits_spi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-elixir_circuits_spi-*.tar
+circuits_spi-*.tar
 
 # Ignore C object files and executables
 /priv

--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
-# ElixirCircuits.SPI
+# Circuits.SPI
 
-[![CircleCI](https://circleci.com/gh/elixir-circuits/spi.svg?style=svg)](https://circleci.com/gh/elixir-circuits/spi)
-[![Hex version](https://img.shields.io/hexpm/v/elixir_circuits_spi.svg "Hex version")](https://hex.pm/packages/elixir_circuits_spi)
+[![CircleCI](https://circleci.com/gh/elixir-circuits/circuits_spi.svg?style=svg)](https://circleci.com/gh/elixir-circuits/circuits_spi)
+[![Hex version](https://img.shields.io/hexpm/v/circuits_spi.svg "Hex version")](https://hex.pm/packages/circuits_spi)
 
-`ElixirCircuits.SPI` provides high level abstractions for interfacing to SPI buses on Linux
-platforms. Internally, it uses the [Linux device
+`Circuits.SPI` provides high level abstractions for interfacing to SPI buses on
+Linux platforms. Internally, it uses the [Linux device
 interface](https://elixir.bootlin.com/linux/latest/source/Documentation/spi/spidev)
 so that it does not require board-dependent code.
 
-# Getting started
+## Getting started
 
-If you're using Nerves or compiling on a Raspberry Pi or other device with I2C
-support, then add `elixir_circuits_i2c` like any other Elixir library:
+If you're using Nerves or compiling on a Raspberry Pi or other device with SPI
+support, then add `circuits_spi` like any other Elixir library:
 
 ```elixir
 def deps do
-  [{:elixir_circuits_spi, "~> 0.1"}]
+  [{:circuits_spi, "~> 0.1"}]
 end
 ```
 
-`ElixirCircuits.SPI` doesn't load device drivers, so you'll need to load any
-necessary ones beforehand. On the Raspberry
-Pi, the [Adafruit Raspberry Pi SPI
+`Circuits.SPI` doesn't load device drivers, so you'll need to load any necessary
+ones beforehand. On the Raspberry Pi, the [Adafruit Raspberry Pi SPI
 instructions](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-4-gpio-setup/configuring-spi)
 may be helpful.
 
-# Examples
+## Examples
 
 The following examples were tested on a Raspberry Pi that was connected to an
 [Erlang Embedded Demo Board](http://solderpad.com/omerk/erlhwdemo/). There's
@@ -34,19 +33,20 @@ work similarly on other embedded Linux platforms.
 
 ## SPI
 
-A [Serial Peripheral Interface](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus)
-(SPI) bus is a common multi-wire bus used to connect components on a circuit
-board. A clock line drives the timing of sending bits between components. Bits
-on the Master Out Slave In `MOSI` line go from the master (usually the
-processor running Linux) to the slave, and bits on the Master In Slave Out
-`MISO` line go the other direction. Bits transfer both directions
-simultaneously. However, much of the time, the protocol used across the SPI
-bus has a request followed by a response and in these cases, bits going the
-"wrong" direction are ignored. This will become more clear in the example below.
+A [Serial Peripheral
+Interface](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) (SPI)
+bus is a common multi-wire bus used to connect components on a circuit board. A
+clock line drives the timing of sending bits between components. Bits on the
+Master Out Slave In `MOSI` line go from the master (usually the processor
+running Linux) to the slave, and bits on the Master In Slave Out `MISO` line go
+the other direction. Bits transfer both directions simultaneously. However, much
+of the time, the protocol used across the SPI bus has a request followed by a
+response and in these cases, bits going the "wrong" direction are ignored. This
+will become more clear in the example below.
 
-The following shows an example Analog to Digital Converter (ADC) that
-reads from either a temperature sensor on CH0 (channel 0) or a potentiometer on
-CH1 (channel 1). It converts the analog measurements to digital, and sends the
+The following shows an example Analog to Digital Converter (ADC) that reads from
+either a temperature sensor on CH0 (channel 0) or a potentiometer on CH1
+(channel 1). It converts the analog measurements to digital, and sends the
 digital measurements to SPI pins on the main processor running Linux (e.g.
 Raspberry Pi). Many processors, like the one on the Raspberry Pi, can't read
 analog signals directly, so they need an ADC to convert the signal.
@@ -71,13 +71,13 @@ the thermometer.
 ```elixir
 # Make sure that you've enabled or loaded the SPI driver or this will
 # fail.
-iex> {:ok, fd} = ElxirCircuits.SPI.open("spidev0.0")
+iex> {:ok, fd} = Circuits.SPI.open("spidev0.0")
 {:ok, 28}
 
 # Read the potentiometer
 
 # Use binary pattern matching to pull out the ADC counts (low 10 bits)
-iex> {:ok, <<_::size(6), counts::size(10)>>} = ElixirCircuits.SPI.transfer(fd, <<0x78, 0x00>>)
+iex> {:ok, <<_::size(6), counts::size(10)>>} = Circuits.SPI.transfer(fd, <<0x78, 0x00>>)
 {:ok, <<1, 197>>}
 
 iex> counts
@@ -98,7 +98,7 @@ and by running `h <<>>` at the IEx prompt.
 ### Where can I get help?
 
 The hardest part is communicating with a device for the first time. The issue is
-usually unrelated to `ElixirCircuits.I2C`. If you expand your searches to
+usually unrelated to `Circuits.SPI`. If you expand your searches to
 include Python and C forums, you'll frequently find the answer.
 
 If that fails, try posting a question to the [Elixir
@@ -106,6 +106,6 @@ Forum](https://elixirforum.com/). Tag the question with `Nerves` and it will
 have a good chance of getting to the right people. Feel free to do this even if
 you're not using Nerves.
 
-# License
+## License
 
 Code from the library is licensed under the Apache License, Version 2.0.

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -1,10 +1,10 @@
-defmodule ElixirCircuits.SPI do
+defmodule Circuits.SPI do
   @moduledoc """
   This module enables Elixir programs to interact with hardware that's connected
   via a SPI bus.
   """
 
-  alias ElixirCircuits.SPI.Nif, as: Nif
+  alias Circuits.SPI.Nif, as: Nif
 
   @type spi_option ::
           {:mode, 0..3}
@@ -60,7 +60,7 @@ defmodule ElixirCircuits.SPI do
   kernel's device tree is not configured. On Raspbian, run `raspi-config` and
   look in the advanced options.
   ```
-  iex> ElixirCircuits.SPI.device_names
+  iex> Circuits.SPI.device_names
   ["spidev0.0", "spidev0.1"]
   ```
   """

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -1,13 +1,13 @@
-defmodule ElixirCircuits.SPI.Nif do
+defmodule Circuits.SPI.Nif do
   @on_load {:load_nif, 0}
   @compile {:autoload, false}
 
   @doc """
-  Elixir interface to SPI Natively Implemented Funtions (NIFs)
+  Elixir interface to SPI Natively Implemented Functions (NIFs)
   """
 
   def load_nif() do
-    nif_binary = Application.app_dir(:elixir_circuits_spi, "priv/spi_nif")
+    nif_binary = Application.app_dir(:circuits_spi, "priv/spi_nif")
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
-defmodule ElixirCircuits.SPI.MixProject do
+defmodule Circuits.SPI.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :elixir_circuits_spi,
+      app: :circuits_spi,
       version: "0.1.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),
-      source_url: "https://github.com/elixir-circuits/spi",
+      source_url: "https://github.com/elixir-circuits/circuits_spi",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
@@ -23,7 +23,7 @@ defmodule ElixirCircuits.SPI.MixProject do
   def application, do: []
 
   defp description do
-    "Elixir access to the hardware SPI interfaces."
+    "Elixir access to the hardware SPI interfaces"
   end
 
   defp package do
@@ -37,7 +37,7 @@ defmodule ElixirCircuits.SPI.MixProject do
         "Makefile"
       ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/elixir-circuits/spi"}
+      links: %{"GitHub" => "https://github.com/elixir-circuits/circuits_spi"}
     }
   end
 

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -179,4 +179,4 @@ static ErlNifFunc nif_funcs[] =
     {"close", 1, spi_close, 0}
 };
 
-ERL_NIF_INIT(Elixir.ElixirCircuits.SPI.Nif, nif_funcs, spi_load, NULL, NULL, spi_unload)
+ERL_NIF_INIT(Elixir.Circuits.SPI.Nif, nif_funcs, spi_load, NULL, NULL, spi_unload)

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -26,7 +26,7 @@
 
 #ifdef DEBUG
 #define log_location stderr
-//#define LOG_PATH "/tmp/elixir_circuits_spi.log"
+//#define LOG_PATH "/tmp/circuits_spi.log"
 #define debug(...) do { enif_fprintf(log_location, __VA_ARGS__); enif_fprintf(log_location, "\r\n"); fflush(log_location); } while(0)
 #define error(...) do { debug(__VA_ARGS__); } while (0)
 #define start_timing() ErlNifTime __start = enif_monotonic_time(ERL_NIF_USEC)


### PR DESCRIPTION
This also adds back the NIF check so that its possible to build docs on OSX.